### PR TITLE
Use openjdk:26-ea-17-jdk-slim to run the app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY src ./src
 RUN mvn clean package -DskipTests
 
 # === Runtime Stage ===
-FROM openjdk:17-jdk-slim
+FROM openjdk:26-ea-17-jdk-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## Details:

App build is failing with error:
```
error: GET https://index.docker.io/v2/library/openjdk/manifests/17-jdk-slim: MANIFEST_UNKNOWN: manifest unknown; unknown tag=17-jdk-slim
```

This PR updates the image tag to fix this.